### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT / Apache-2.0"
 exclude = ["tests/*"]
 
 [dependencies]
-byteorder = "1.0"
 rayon = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,3 @@
-use byteorder::ReadBytesExt;
 use error::{Error, Result, UnsupportedFeature};
 use huffman::{fill_default_mjpeg_tables, HuffmanDecoder, HuffmanTable};
 use marker::Marker;
@@ -126,7 +125,7 @@ impl<R: Read> Decoder<R> {
             // The metadata has already been read.
             return Ok(Vec::new());
         }
-        else if self.frame.is_none() && (self.reader.read_u8()? != 0xFF || Marker::from_u8(try!(self.reader.read_u8())) != Some(Marker::SOI)) {
+        else if self.frame.is_none() && (super::read_u8(&mut self.reader)? != 0xFF || Marker::from_u8(super::read_u8(&mut self.reader)?) != Some(Marker::SOI)) {
             return Err(Error::Format("first two bytes is not a SOI marker".to_owned()));
         }
 
@@ -337,14 +336,14 @@ impl<R: Read> Decoder<R> {
         // libjpeg allows this though and there are images in the wild utilising it, so we are
         // forced to support this behavior.
         // Sony Ericsson P990i is an example of a device which produce this sort of JPEGs.
-        while self.reader.read_u8()? != 0xFF {}
+        while super::read_u8(&mut self.reader)? != 0xFF {}
 
-        let mut byte = self.reader.read_u8()?;
+        let mut byte = super::read_u8(&mut self.reader)?;
 
         // Section B.1.1.2
         // "Any marker may optionally be preceded by any number of fill bytes, which are bytes assigned code X’FF’."
         while byte == 0xFF {
-            byte = self.reader.read_u8()?;
+            byte = super::read_u8(&mut self.reader)?;
         }
 
         match byte {

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -1,4 +1,3 @@
-use byteorder::ReadBytesExt;
 use error::{Error, Result};
 use marker::Marker;
 use parser::ScanInfo;
@@ -122,11 +121,11 @@ impl HuffmanDecoder {
             // Fill with zero bits if we have reached the end.
             let byte = match self.marker {
                 Some(_) => 0,
-                None => reader.read_u8()?,
+                None => super::read_u8(&mut *reader)?,
             };
 
             if byte == 0xFF {
-                let mut next_byte = reader.read_u8()?;
+                let mut next_byte = super::read_u8(&mut *reader)?;
 
                 // Check for byte stuffing.
                 if next_byte != 0x00 {
@@ -137,7 +136,7 @@ impl HuffmanDecoder {
                     // Section B.1.1.2
                     // "Any marker may optionally be preceded by any number of fill bytes, which are bytes assigned code X’FF’."
                     while next_byte == 0xFF {
-                        next_byte = reader.read_u8()?;
+                        next_byte = super::read_u8(&mut *reader)?;
                     }
 
                     match next_byte {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 
 #![deny(missing_docs)]
 
-extern crate byteorder;
 #[cfg(feature="rayon")]
 extern crate rayon;
 
@@ -43,3 +42,13 @@ mod marker;
 mod parser;
 mod upsampler;
 mod worker;
+
+fn read_u8(mut r: impl std::io::Read) -> std::io::Result<u8> {
+    let mut buf = [0; 1];
+    r.read_exact(&mut buf).map(|()| buf[0])
+}
+
+fn read_be_u16(mut r: impl std::io::Read) -> std::io::Result<u16> {
+    let mut buf = [0; 2];
+    r.read_exact(&mut buf).map(|()| u16::from_be_bytes(buf))
+}

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -132,7 +132,6 @@ impl Marker {
             0xFD => Some(JPGn(13)),
             0xFE => Some(COM),
             0xFF => None, // Fill byte
-            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is only ever really used for a single big-endian conversion. Since Rust 1.32, we can use the functions defined on the primitive to do that. IMHO dropping a dependency is worth the change.