### PR TITLE
Change color_convert_line_cmyk so it gets auto vectorized

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -145,7 +145,7 @@ impl<R: Read> Decoder<R> {
 
     /// Returns raw exif data, starting at the TIFF header, if the image contains any.
     ///
-    /// The returned value will be `None` until a call to `decode` has returned `Ok`.    
+    /// The returned value will be `None` until a call to `decode` has returned `Ok`.
     pub fn exif_data(&self) -> Option<&[u8]> {
         self.exif_data.as_ref().map(|v| v.as_slice())
     }
@@ -296,7 +296,7 @@ impl<R: Read> Decoder<R> {
                         }).collect();
                     }
 
-                    
+
                     if frame.coding_process == CodingProcess::Lossless {
                         let (marker, data) = self.decode_scan_lossless(&frame, &scan)?;
 
@@ -1095,11 +1095,8 @@ fn color_convert_line_ycck(data: &mut [u8]) {
 }
 
 fn color_convert_line_cmyk(data: &mut [u8]) {
-    for chunk in data.chunks_exact_mut(4) {
-        chunk[0] = 255 - chunk[0];
-        chunk[1] = 255 - chunk[1];
-        chunk[2] = 255 - chunk[2];
-        chunk[3] = 255 - chunk[3];
+    for i in 0..data.len() {
+        data[i] = 255 - data[i];
     }
 }
 


### PR DESCRIPTION
Finally came back to this PR, looking back into it changing the code so the compiler can auto vectorize seemed like the best solution

[Comparing the generated asm](https://godbolt.org/#z:OYLghAFBqd5TKALEBjA9gEwKYFFMCWALugE4A0BIEAZgQDbYB2AhgLbYgDkAjF%2BTXRMiAZVQtGIHgBYBQogFUAztgAKAD24AGfgCsp5eiyahSAVyVFyKxqiIEh1ZpgDC6embZMDzgDIEmbAA5TwAjbFIQAE5yAAd0JWIHJjcPLwN4xPshf0CQtnDImJtsO2SRIhZSIlTPbx5rbFtspgqqolzgsIjo60rq2vSGy3bO/MLogEprdDNSVE4uWLNQgGoaJlWMejIAfQwmADcIol36AOx9tgBPAGsITBZKkFWAUgAmADY2MyI3gFYAEJmAAcr3%2BABFJm8AOyA15aACCqxR6zIWyQZiYt1WAVWj0qADpUJjsUpdth1Cw7LsfkQINJoa84Qjkaj2SSsbdwYCtOCIW8AMwC97/f6rAC0GK5PL5kNegvhSPZHNJ3KBPH5QpFYsl0uxPM18sVrJVqM5BqB7y1Cp14qlFvVgOtxqVbLNjp5gptwtWovt%2Bqd3tdptRzIhrPDrK403o3H%2B/G8XB05HQ3AAShY/kpZvNsG93oK%2BOQiNoY9NbiB/lpDNxpPw2FWa0mU2muPwlCAa6XkzHyHBYCgMDh8MQyJRqHRGKwONxi4JhGIJJwZHJhMo1Jpe%2BR9O9DMZTFnGs1kk4mK53HUfOext1Ip84gkkkJBvVH1lkreCj0HyUykI2gGS8hmPUoWkAjoLnGH8%2BnaV8DBGaovwmT5phzOYFm4ZY1g2LZ3D2A5jmqM4LiuO4HieFgXg%2Bb5fgBYEwUhJkWWVVFBFIXFcU2LRCUJAkWEJacIGYt0zRRfieQIH07T1CSgSkkNWJRKMkRUxE%2BzjLgE3IFt%2BDbTNLFWdC8wLQV3n4HsdEmaYkGwFgcEiYTay4etyEbasdLLVNuA7LsSzLazyErDzNMFRMvLbCyAv7RAB2QNB0DYWIGAiCcIAwJKUsiUgeDFGspyICJOwgUIvNCAIqmuOd%2BAyjhhAAeSYegqu3HA2APSRWoIUgwIIY5O23SlSl%2BRZiwCQrNJTc5QlISq3BwLyiFIAhG14PsaCMYAlAANQIbAAHd6tiZhqrXURxEkVcF0UFQNC8/QGiMEwQHMSxDAIUJO0gaZ0FiFoBolFxVl%2BogJUYY56FtczQP/bwIGceCGj8KC7wyJ8WkR99nyYZCemGJpeoA/oamAt8/3A4ncciYZicxxDILyVGeDQ3NMIaJbsFGjT43C7c21eohUFWHhCTFQktFWCADKsVZRxIDiPiLchVjcTLGAVwtmai3tAuCmtNNc9zmwinzrD8yy%2BziiAh0S5L1bSjK7Z6HK8oEBhCtIYrSu3crWFIFri1q5giEa5qvLajrFhTQgerKfqvKG1ARtO8ami86bZv9%2Bao4s5bVr4aYNpYLbdoOo6TrWs6l0u2Rro3O7t13fdnoF97PvgH6/uSAGgZBsHsAhqGOwJ2GzwvNI32Rxnv2prGMdJtGPxyFGZ4QkeKbghf8ZPInRhXiYac3ieEMp/e8ZZjDOD3DmudjHnPL57gBaFkWxYlqWj1lwh5dMvcVdtrKv9JjaysjZOyDlqB3xcg2JsD9Wym07N2AKFZYGhV5vA9s/kdZQOhrpbymCLaBSIokRw0ggA%3D%3D%3D)