### PR TITLE
Add a method to determine the size in pixels for a given format

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -38,7 +38,7 @@ pub enum PixelFormat {
 
 impl PixelFormat {
     /// Determine the size in bytes of each pixel in this format
-    pub fn pixel_size(&self) -> usize {
+    pub fn pixel_bytes(&self) -> usize {
         match self {
             PixelFormat::L8 => 1,
             PixelFormat::RGB24 => 3,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -36,6 +36,17 @@ pub enum PixelFormat {
     CMYK32,
 }
 
+impl PixelFormat {
+    /// Determine the size in bytes of each pixel in this format
+    pub fn pixel_size(&self) -> usize {
+        match self {
+            Self::L8 => 1,
+            Self::RGB24 => 3,
+            Self::CMYK32 => 4,
+        }
+    }
+}
+
 /// Represents metadata of an image.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ImageInfo {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -40,9 +40,9 @@ impl PixelFormat {
     /// Determine the size in bytes of each pixel in this format
     pub fn pixel_size(&self) -> usize {
         match self {
-            Self::L8 => 1,
-            Self::RGB24 => 3,
-            Self::CMYK32 => 4,
+            PixelFormat::L8 => 1,
+            PixelFormat::RGB24 => 3,
+            PixelFormat::CMYK32 => 4,
         }
     }
 }


### PR DESCRIPTION
Sometimes it can be useful to manipulate pixels without changing their content. That code generally needs to know the size of each pixel in bytes, so that it can determine (for example) the byte offset of a line ending or the byte index of a particular pixel.

This is a utility function that makes it convenient to determine the byte width of each pixel when using a particular format.

(Note: This is essentially just the inverse of [the operation performed](https://github.com/kaksmet/jpeg-decoder/blob/c8e25252ec6c6888db8eb866dec47131c34949a3/src/decoder.rs#L95-L99) when the `PixelFormat` value is first created)