### PR TITLE
fix clippy::into_iter_on_array error in decoder

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -232,7 +232,7 @@ impl<R: Read> Decoder<R> {
                 Marker::DQT => {
                     let tables = parse_dqt(&mut self.reader)?;
 
-                    for (i, &table) in tables.into_iter().enumerate() {
+                    for (i, &table) in tables.iter().enumerate() {
                         if let Some(table) = table {
                             let mut unzigzagged_table = [0u16; 64];
 


### PR DESCRIPTION
[Rust is trying to add `IntoIterator` for arrays](https://github.com/rust-lang/rust/pull/65819#issuecomment-547775045), which would break this.  So might as well do it the way that's forward-compatible and also shorter.