### PR TITLE
Bump minimum Rust version to 1.34.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.28.0
+  - 1.34.2
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ fn main() {
 ```
 
 ## Requirements
-This crate compiles only with rust >= 1.28.
+This crate compiles only with rust >= 1.34.

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -132,7 +132,6 @@ impl Marker {
             0xFD => Some(JPGn(13)),
             0xFE => Some(COM),
             0xFF => None, // Fill byte
-            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
Tests have been failing for a while due to lack of support for 1.28 in rayon and its dependencies. This bumps the minimum Rust version to 1.34 to [match the `image` crate](https://github.com/image-rs/image/pull/984).