### PR TITLE
Fix the link to travis CI in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jpeg-decoder
 
-[![Travis Build Status](https://travis-ci.org/kaksmet/jpeg-decoder.svg?branch=master)](https://travis-ci.org/kaksmet/jpeg-decoder)
+[![Travis Build Status](https://travis-ci.org/image-rs/jpeg-decoder.svg?branch=master)](https://travis-ci.org/image-rs/jpeg-decoder)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/k65rrkd0f8yb4o9w/branch/master?svg=true)](https://ci.appveyor.com/project/kaksmet/jpeg-decoder/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/jpeg-decoder.svg)](https://crates.io/crates/jpeg-decoder)
 


### PR DESCRIPTION
The link was broken since the repo was handed over by @kaksmet