### PR TITLE
Use the 'Wrapping' integer type instead of wrapping methods in IDCT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jpeg-decoder
 
-[![Rust CI](https://github.com/image-rs/jpeg-decoder/workflows/Rust%20CI/badge.svg)
+[![Rust CI](https://github.com/image-rs/jpeg-decoder/workflows/Rust%20CI/badge.svg)](https://github.com/image-rs/jpeg-decoder/actions)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/k65rrkd0f8yb4o9w/branch/master?svg=true)](https://ci.appveyor.com/project/kaksmet/jpeg-decoder/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/jpeg-decoder.svg)](https://crates.io/crates/jpeg-decoder)
 


### PR DESCRIPTION
The IDCT code is full of wrapping integer arithmetic.
This commit changes the code to use `std::num::Wrapping` instead of `i32::wrapping_*` methods.

This is a big commit in term of number of lines changed, but this should have absolutely no impact on the generated machine code.

This just makes the IDCT code much easier to read, which should in turn make it easier to optimize.