### PR TITLE
Faster color conversions

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -861,7 +861,7 @@ fn compute_image_parallel(components: &[Component],
     for (row, line) in image.chunks_mut(line_size)
          .enumerate() {
              upsampler.upsample_and_interleave_row(&data, row, output_size.width as usize, line);
-             color_convert_func(line, output_size.width as usize);
+             color_convert_func(line);
          }
 
     Ok(image)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -897,34 +897,33 @@ fn choose_color_convert_func(component_count: usize,
 fn color_convert_line_null(_data: &mut [u8], _width: usize) {
 }
 
-fn color_convert_line_ycbcr(data: &mut [u8], width: usize) {
-    for i in 0 .. width {
-        let (r, g, b) = ycbcr_to_rgb(data[i * 3], data[i * 3 + 1], data[i * 3 + 2]);
-
-        data[i * 3]     = r;
-        data[i * 3 + 1] = g;
-        data[i * 3 + 2] = b;
+fn color_convert_line_ycbcr(data: &mut [u8], _width: usize) {
+    for chunk in data.chunks_exact_mut(3) {
+        let (r, g, b) = ycbcr_to_rgb(chunk[0], chunk[1], chunk[2]);
+        chunk[0] = r;
+        chunk[1] = g;
+        chunk[2] = b;
     }
 }
 
-fn color_convert_line_ycck(data: &mut [u8], width: usize) {
-    for i in 0 .. width {
-        let (r, g, b) = ycbcr_to_rgb(data[i * 4], data[i * 4 + 1], data[i * 4 + 2]);
-        let k = data[i * 4 + 3];
+fn color_convert_line_ycck(data: &mut [u8], _width: usize) {
+    for chunk in data.chunks_exact_mut(4) {
+        let (r, g, b) = ycbcr_to_rgb(chunk[0], chunk[1], chunk[2]);
+        let k = chunk[3];
+        chunk[0] = r;
+        chunk[1] = g;
+        chunk[2] = b;
+        chunk[3] = 255 - k;
 
-        data[i * 4]     = r;
-        data[i * 4 + 1] = g;
-        data[i * 4 + 2] = b;
-        data[i * 4 + 3] = 255 - k;
     }
 }
 
-fn color_convert_line_cmyk(data: &mut [u8], width: usize) {
-    for i in 0 .. width {
-        data[i * 4]     = 255 - data[i * 4];
-        data[i * 4 + 1] = 255 - data[i * 4 + 1];
-        data[i * 4 + 2] = 255 - data[i * 4 + 2];
-        data[i * 4 + 3] = 255 - data[i * 4 + 3];
+fn color_convert_line_cmyk(data: &mut [u8], _width: usize) {
+    for chunk in data.chunks_exact_mut(4) {
+        chunk[0] = 255 - chunk[0];
+        chunk[1] = 255 - chunk[1];
+        chunk[2] = 255 - chunk[2];
+        chunk[3] = 255 - chunk[3];
     }
 }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -841,7 +841,7 @@ fn compute_image_parallel(components: &[Component],
          .enumerate()
          .for_each(|(row, line)| {
              upsampler.upsample_and_interleave_row(&data, row, output_size.width as usize, line);
-             color_convert_func(line, output_size.width as usize);
+             color_convert_func(line);
          });
 
     Ok(image)
@@ -870,7 +870,7 @@ fn compute_image_parallel(components: &[Component],
 fn choose_color_convert_func(component_count: usize,
                              _is_jfif: bool,
                              color_transform: Option<AdobeColorTransform>)
-                             -> Result<fn(&mut [u8], usize)> {
+                             -> Result<fn(&mut [u8])> {
     match component_count {
         3 => {
             // http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/JPEG.html#Adobe
@@ -894,10 +894,10 @@ fn choose_color_convert_func(component_count: usize,
     }
 }
 
-fn color_convert_line_null(_data: &mut [u8], _width: usize) {
+fn color_convert_line_null(_data: &mut [u8]) {
 }
 
-fn color_convert_line_ycbcr(data: &mut [u8], _width: usize) {
+fn color_convert_line_ycbcr(data: &mut [u8]) {
     for chunk in data.chunks_exact_mut(3) {
         let (r, g, b) = ycbcr_to_rgb(chunk[0], chunk[1], chunk[2]);
         chunk[0] = r;
@@ -906,7 +906,7 @@ fn color_convert_line_ycbcr(data: &mut [u8], _width: usize) {
     }
 }
 
-fn color_convert_line_ycck(data: &mut [u8], _width: usize) {
+fn color_convert_line_ycck(data: &mut [u8]) {
     for chunk in data.chunks_exact_mut(4) {
         let (r, g, b) = ycbcr_to_rgb(chunk[0], chunk[1], chunk[2]);
         let k = chunk[3];
@@ -918,7 +918,7 @@ fn color_convert_line_ycck(data: &mut [u8], _width: usize) {
     }
 }
 
-fn color_convert_line_cmyk(data: &mut [u8], _width: usize) {
+fn color_convert_line_cmyk(data: &mut [u8]) {
     for chunk in data.chunks_exact_mut(4) {
         chunk[0] = 255 - chunk[0];
         chunk[1] = 255 - chunk[1];


### PR DESCRIPTION
Speeds up end-to-end decoding by 5% in single-threaded mode. Considerably less than that in multi-threaded mode which is bottlenecked by #155 instead.

Another similar improvement will be possible once the float-to-int conversions defined as saturating will actually reach stable channel (https://github.com/rust-lang/rust/pull/71269) and the crate's MSVR reaches this version.