### PR TITLE
Height of zero triggering invalid dimensions

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -196,9 +196,6 @@ impl<R: Read> Decoder<R> {
                     if frame.precision != 8 {
                         return Err(Error::Unsupported(UnsupportedFeature::SamplePrecision(frame.precision)));
                     }
-                    if frame.image_size.height == 0 {
-                        return Err(Error::Unsupported(UnsupportedFeature::DNL));
-                    }
                     if component_count != 1 && component_count != 3 && component_count != 4 {
                         return Err(Error::Unsupported(UnsupportedFeature::ComponentCount(component_count as u8)));
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use byteorder::{BigEndian, ReadBytesExt};
-use error::{Error, Result};
+use error::{Error, Result, UnsupportedFeature};
 use huffman::{HuffmanTable, HuffmanTableClass};
 use marker::Marker;
 use marker::Marker::*;
@@ -171,6 +171,9 @@ pub fn parse_sof<R: Read>(reader: &mut R, marker: Marker) -> Result<FrameInfo> {
     // height:
     // "Value 0 indicates that the number of lines shall be defined by the DNL marker and
     //     parameters at the end of the first scan (see B.2.5)."
+    if height == 0 {
+        return Err(Error::Unsupported(UnsupportedFeature::DNL));
+    }
 
     if width == 0 {
         return Err(Error::Format("zero width in frame header".to_owned()));


### PR DESCRIPTION
Because of [this comment](https://github.com/image-rs/jpeg-decoder/pull/163#discussion_r499169909) in #163 I dug a little deeper into the reason the "invalid dimensions" error is triggered. For the image of #161, it turned out it was because it height was zero, which would trigger an error for an unsupported feature only later, so I moved this check earlier.