### PR TITLE
Make small perf refactors, clippy and grammar fixes

### DIFF
--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -3,7 +3,6 @@ use error::{Error, Result};
 use marker::Marker;
 use parser::ScanInfo;
 use std::io::Read;
-use std::iter::repeat;
 
 const LUT_BITS: u8 = 8;
 
@@ -254,8 +253,7 @@ fn derive_huffman_codes(bits: &[u8; 16]) -> Result<(Vec<u16>, Vec<u8>)> {
     let huffsize = bits.iter()
                        .enumerate()
                        .fold(Vec::new(), |mut acc, (i, &value)| {
-                           let mut repeated_size: Vec<u8> = repeat((i + 1) as u8).take(value as usize).collect();
-                           acc.append(&mut repeated_size);
+                           acc.extend(std::iter::repeat((i + 1) as u8).take(value as usize));
                            acc
                        });
 

--- a/src/idct.rs
+++ b/src/idct.rs
@@ -16,7 +16,7 @@ pub(crate) fn choose_idct_size(full_size: Dimensions, requested_size: Dimensions
         }
     }
 
-    return 8;
+    8
 }
 
 #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -434,8 +434,8 @@ pub fn parse_dqt<R: Read>(reader: &mut R) -> Result<[Option<[u16; 64]>; 4]> {
 
         let mut table = [0u16; 64];
 
-        for i in 0 .. 64 {
-            table[i] = match precision {
+        for item in table.iter_mut() {
+            *item = match precision {
                 0 => reader.read_u8()? as u16,
                 1 => reader.read_u16::<BigEndian>()?,
                 _ => unreachable!(),

--- a/src/upsampler.rs
+++ b/src/upsampler.rs
@@ -128,9 +128,7 @@ impl Upsample for UpsamplerH1V1 {
                     output: &mut [u8]) {
         let input = &input[row * row_stride ..];
 
-        for i in 0 .. output_width {
-            output[i] = input[i];
-        }
+        output[..output_width].copy_from_slice(&input[..output_width]);
     }
 }
 


### PR DESCRIPTION
I found some places for improvement based on clippy and experimentation. The benchmarks seemed a bit noisy from run to run. Overall, I believe I had more small performance gains than regressions on my computer but that may not replicate. 

`decoder.rs`  
Refactor spectral selection difference magnitude to remove error check from non-zero match arm, better matches table F.1 on page 89 of the document, 93 of the [PDF](https://www.w3.org/Graphics/JPEG/itu-t81.pdf)
Remove unnecessary closure
Return from clamp_to_u8 by expression instead of let value
`huffman.rs`  
Avoid collecting in huffsize fold
`idct.rs`  
Remove return
`parser.rs`  
Use mutable iterator instead of for loop
`upsampler.rs`  
Use copy_from_slice instead of for loop

```
decode a 512x512 JPEG
    time:   [4.1549 ms 4.1638 ms 4.1733 ms]
    change: [-4.6042% -4.1612% -3.7614%] (p = 0.00 < 0.05)
    Performance has improved.

decode a 512x512 progressive JPEG
    time:   [7.6885 ms 7.7178 ms 7.7545 ms]
    change: [-0.7646% -0.2729% +0.3227%] (p = 0.34 > 0.05)
    No change in performance detected.

Benchmarking decode a 512x512 grayscale JPEG
    time:   [1.1805 ms 1.1842 ms 1.1880 ms]
    change: [+0.4658% +0.9305% +1.3867%] (p = 0.00 < 0.05)
    Change within noise threshold.

Benchmarking extract metadata from an imag
    time:   [1.3026 us 1.3054 us 1.3085 us]
    change: [-4.5689% -4.2494% -3.8972%] (p = 0.00 < 0.05)
    Performance has improved.
```