### PR TITLE
Eliminate some bounds checks in IDCT

### DIFF
--- a/src/idct.rs
+++ b/src/idct.rs
@@ -2,10 +2,7 @@
 // One example is tests/crashtest/images/imagetestsuite/b0b8914cc5f7a6eff409f16d8cc236c5.jpg
 // That's why wrapping operators are needed.
 use crate::parser::Dimensions;
-use std::{
-    convert::TryFrom,
-    num::Wrapping,
-};
+use std::{convert::TryFrom, convert::TryInto, num::Wrapping};
 
 pub(crate) fn choose_idct_size(full_size: Dimensions, requested_size: Dimensions) -> usize {
     fn scaled(len: u16, scale: usize) -> u16 { ((len as u32 * scale as u32 - 1) / 8 + 1) as u16 }
@@ -54,7 +51,6 @@ pub fn dequantize_and_idct_block_8x8(
     output_linestride: usize,
     output: &mut [u8]
 ) {
-    debug_assert_eq!(coefficients.len(), 64);
     let output = output
         .chunks_mut(output_linestride);
     dequantize_and_idct_block_8x8_inner(coefficients, quantization_table, output)
@@ -75,6 +71,9 @@ fn dequantize_and_idct_block_8x8_inner<'a, I>(
         "Output iterator has the wrong length: {}",
         output.len()
     );
+
+    // optimizer hint to eliminate bounds checks within loops
+    let coefficients: &[i16; 64] = coefficients.try_into().unwrap();
 
     let mut temp = [Wrapping(0); 64];
 

--- a/src/idct.rs
+++ b/src/idct.rs
@@ -2,7 +2,7 @@
 // One example is tests/crashtest/images/imagetestsuite/b0b8914cc5f7a6eff409f16d8cc236c5.jpg
 // That's why wrapping operators are needed.
 use crate::parser::Dimensions;
-use std::{convert::TryFrom, convert::TryInto, num::Wrapping};
+use std::{convert::TryFrom, num::Wrapping};
 
 pub(crate) fn choose_idct_size(full_size: Dimensions, requested_size: Dimensions) -> usize {
     fn scaled(len: u16, scale: usize) -> u16 { ((len as u32 * scale as u32 - 1) / 8 + 1) as u16 }
@@ -73,7 +73,7 @@ fn dequantize_and_idct_block_8x8_inner<'a, I>(
     );
 
     // optimizer hint to eliminate bounds checks within loops
-    let coefficients: &[i16; 64] = coefficients.try_into().unwrap();
+    assert!(coefficients.len() == 64);
 
     let mut temp = [Wrapping(0); 64];
 


### PR DESCRIPTION
Convert a debug assert into an actual assert to use as an optimizer hint. Eliminates a bunch of bounds checks.

It reduces the number of assembly instructions, but I did not see any measurable performance improvement on my machine.

Instruction counts for `jpeg_decoder::worker::immediate::ImmediateWorker::append_row_immediate` where this gets inlined: before - 1420, after - 1363.

Top 10 instructions with counts, before:

```
    385 mov
    150 lea
     95 add
     86 imul
     85 cmp
     61 jmp
     50 sar
     49 sub
     36 call
     33 movzx
```

Instruction counts after:

```
    355 mov
    150 lea
     91 add
     86 imul
     83 cmp
     53 jmp
     50 sar
     48 sub
     35 call
     34 movzx
```