### PR TITLE
Add support for extracting Exif data

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -75,6 +75,8 @@ pub struct Decoder<R> {
 
     icc_markers: Vec<IccChunk>,
 
+    exif_data: Option<Vec<u8>>,
+
     // Used for progressive JPEGs.
     coefficients: Vec<Vec<i16>>,
     // Bitmask of which coefficients has been completely decoded.
@@ -95,6 +97,7 @@ impl<R: Read> Decoder<R> {
             is_jfif: false,
             is_mjpeg: false,
             icc_markers: Vec::new(),
+            exif_data: None,
             coefficients: Vec::new(),
             coefficients_finished: [0; MAX_COMPONENTS],
         }
@@ -122,6 +125,13 @@ impl<R: Read> Decoder<R> {
             },
             None => None,
         }
+    }
+
+    /// Returns raw exif data, starting at the TIFF header, if the image contains any.
+    ///
+    /// The returned value will be `None` until a call to `decode` has returned `Ok`.    
+    pub fn exif_data(&self) -> Option<Vec<u8>> {
+        self.exif_data.as_ref().map(|v| v.clone())
     }
 
     /// Returns the embeded icc profile if the image contains one.
@@ -374,6 +384,7 @@ impl<R: Read> Decoder<R> {
                             },
                             AppData::Avi1 => self.is_mjpeg = true,
                             AppData::Icc(icc) => self.icc_markers.push(icc),
+                            AppData::Exif(data) => self.exif_data = Some(data),
                         }
                     }
                 },

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -130,8 +130,8 @@ impl<R: Read> Decoder<R> {
     /// Returns raw exif data, starting at the TIFF header, if the image contains any.
     ///
     /// The returned value will be `None` until a call to `decode` has returned `Ok`.    
-    pub fn exif_data(&self) -> Option<Vec<u8>> {
-        self.exif_data.as_ref().map(|v| v.clone())
+    pub fn exif_data(&self) -> Option<&[u8]> {
+        self.exif_data.as_ref().map(|v| v.as_slice())
     }
 
     /// Returns the embeded icc profile if the image contains one.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -42,3 +42,18 @@ fn read_icc_profile() {
     // "acsp" is a mandatory string in ICC profile headers.
     assert_eq!(&profile[36..40], b"acsp");
 }
+
+#[test]
+fn read_exif_data() {
+    let path = Path::new("tests")
+        .join("reftest")
+        .join("images")
+        .join("ycck.jpg");
+
+    let mut decoder = jpeg::Decoder::new(File::open(&path).unwrap());
+    decoder.decode().unwrap();
+
+    let exif_data = decoder.exif_data().unwrap();
+    // exif data start as a TIFF header
+    assert_eq!(&exif_data[0..8], b"\x49\x49\x2A\x00\x08\x00\x00\x00");
+}


### PR DESCRIPTION
Implements #42.

Also a first step towards [image#1045](https://github.com/image-rs/image/issues/1045).

Exposes Exif data as an `Option<Vec<u8>>` that can be parsed by client code e.g. using `kamadak-exif` (or simply to pass it on when saving the file again):

```rust
    let path = Path::new("tests")
        .join("reftest")
        .join("images")
        .join("ycck.jpg");

    let mut decoder = jpeg::Decoder::new(File::open(&path).unwrap());
    decoder.decode().unwrap();

    let exif_data = decoder.exif_data().unwrap();
    let exif_reader = exif::Reader::new();
    let exif = exif_reader.read_raw(exif_data).unwrap();
    for field in exif.fields() {
        println!("{}", field.display_value());
    }
```

Not 100% sure about the `exif_data()` method. Since Exif might contain up to 64kb a copy might be a bit much.
Perhaps:
```rust
pub fn take_exif_data(&mut self) -> Option<Vec<u8>> {
    self.exif_data.take()
}
```
or
```rust
pub fn exif_data(&self) -> Option<&Vec<u8>> {
    self.exif_data.as_ref()
}
```

I guess exif data might be inspected multiple times e.g. to determine orientation?