### PR TITLE
Update meta data for release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.2.1 (2012-12-09)
+
+- Fix decoding error due to conflict of lossless with some spectral selections.
+
 ## v0.2.0 (2021-12-04)
 
 - Added Lossless JPEG support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpeg-decoder"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The image-rs Developers"]
 description = "JPEG decoder"
 documentation = "https://docs.rs/jpeg-decoder"


### PR DESCRIPTION
To fix the regression in `0.2` and unblock the bump in `image`.