### PR TITLE
Remove feature gate on the std feature

### DIFF
--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1,10 +1,9 @@
 mod immediate;
-#[cfg(feature = "std")]
 mod multithreaded;
 
-#[cfg(all(feature = "std", not(any(target_arch = "asmjs", target_arch = "wasm32"))))]
+#[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))]
 pub use self::multithreaded::MultiThreadedWorker as PlatformWorker;
-#[cfg(any(not(feature = "std"), target_arch = "asmjs", target_arch = "wasm32"))]
+#[cfg(any(target_arch = "asmjs", target_arch = "wasm32"))]
 pub use self::immediate::ImmediateWorker as PlatformWorker;
 
 use alloc::sync::Arc;


### PR DESCRIPTION
This improves the decode performance to up to 40%. Am I missing something? I wouldn't expect something this simple to add such a big change :sweat_smile:.
The feature gate was added by #196, but no `std` feature is present in the Cargo.toml, so the multithreaded worker would never get used.