### PR TITLE
Remove 10 bounds checks from `dequantize_and_idct_block_8x8`

### DIFF
--- a/src/idct.rs
+++ b/src/idct.rs
@@ -145,6 +145,9 @@ fn dequantize_and_idct_block_8x8_inner<'a, I>(
         // to encode as 0..255 by adding 128, so we'll add that before the shift
         const X_SCALE: i32 = 65536 + (128 << 17);
 
+        // eliminate downstream bounds checks
+        let output_chunk = &mut output_chunk[..8];
+
         // TODO When the minimum rust version supports it
         // let [s0, rest @ ..] = chunk;
         let (s0, rest) = chunk.split_first().unwrap();


### PR DESCRIPTION
Removes bounds checks from the following lines:

https://github.com/image-rs/jpeg-decoder/blob/55a4a9a32b45b968694d3b656f4d9669a0ecbc03/src/idct.rs#L153-L160

https://github.com/image-rs/jpeg-decoder/blob/55a4a9a32b45b968694d3b656f4d9669a0ecbc03/src/idct.rs#L167-L168

and makes the code autovectorize

https://rust.godbolt.org/z/vP9svecsv