### PR TITLE
Assume CMYK if App14 marker is missing

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1229,9 +1229,10 @@ fn choose_color_convert_func(
             match color_transform {
                 Some(AdobeColorTransform::Unknown) => Ok(color_convert_line_cmyk),
                 Some(_) => Ok(color_convert_line_ycck),
-                None => Err(Error::Format(
-                    "4 components without Adobe APP14 metadata to indicate color space".to_owned(),
-                )),
+                None => {
+                    // Assume CMYK because no APP14 marker was found
+                    Ok(color_convert_line_cmyk)
+                },
             }
         }
         _ => panic!(),


### PR DESCRIPTION
Assume image is encoded as CMYK if App14 marker (Adobe colortransform) is missing.

This is the same behavior than libjpeg/mozjpeg (See [jdapimin.c](https://github.com/mozilla/mozjpeg/blob/5552483db96d9c5c18ae60a7e3bff2be99d78247/jdapimin.c#L172-L189)) and fixes #219 