### PR TITLE
Update to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["jpeg", "jpg", "decoder", "image"]
 license = "MIT / Apache-2.0"
 exclude = ["tests/*"]
+edition = "2018"
 
 [dependencies]
 rayon = { version = "1.0", optional = true }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,3 @@
-use crate::read_u8;
 use alloc::borrow::ToOwned;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -6,18 +5,19 @@ use alloc::{format, vec};
 use core::cmp;
 use core::mem;
 use core::ops::Range;
-use error::{Error, Result, UnsupportedFeature};
-use huffman::{fill_default_mjpeg_tables, HuffmanDecoder, HuffmanTable};
-use marker::Marker;
-use parser::{
+use std::convert::TryInto;
+use std::io::Read;
+use crate::read_u8;
+use crate::error::{Error, Result, UnsupportedFeature};
+use crate::huffman::{fill_default_mjpeg_tables, HuffmanDecoder, HuffmanTable};
+use crate::marker::Marker;
+use crate::parser::{
     parse_app, parse_com, parse_dht, parse_dqt, parse_dri, parse_sof, parse_sos,
     AdobeColorTransform, AppData, CodingProcess, Component, Dimensions, EntropyCoding, FrameInfo,
     IccChunk, ScanInfo,
 };
-use std::convert::TryInto;
-use std::io::Read;
-use upsampler::Upsampler;
-use worker::{PlatformWorker, RowData, Worker};
+use crate::upsampler::Upsampler;
+use crate::worker::{PlatformWorker, RowData, Worker};
 
 pub const MAX_COMPONENTS: usize = 4;
 

--- a/src/decoder/lossless.rs
+++ b/src/decoder/lossless.rs
@@ -1,10 +1,10 @@
-use decoder::{Decoder, MAX_COMPONENTS};
-use error::{Error, Result};
-use huffman::HuffmanDecoder;
-use marker::Marker;
-use parser::Predictor;
-use parser::{Component, FrameInfo, ScanInfo};
 use std::io::Read;
+use crate::decoder::{Decoder, MAX_COMPONENTS};
+use crate::error::{Error, Result};
+use crate::huffman::HuffmanDecoder;
+use crate::marker::Marker;
+use crate::parser::Predictor;
+use crate::parser::{Component, FrameInfo, ScanInfo};
 
 impl<R: Read> Decoder<R> {
     /// decode_scan_lossless

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -2,11 +2,11 @@ use alloc::borrow::ToOwned;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::iter;
-use crate::read_u8;
-use error::{Error, Result};
-use marker::Marker;
-use parser::ScanInfo;
 use std::io::Read;
+use crate::read_u8;
+use crate::error::{Error, Result};
+use crate::marker::Marker;
+use crate::parser::ScanInfo;
 
 const LUT_BITS: u8 = 8;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,12 +2,12 @@ use alloc::borrow::ToOwned;
 use alloc::{format, vec};
 use alloc::vec::Vec;
 use core::ops::{self, Range};
-use crate::{read_u16_from_be, read_u8};
-use error::{Error, Result, UnsupportedFeature};
-use huffman::{HuffmanTable, HuffmanTableClass};
-use marker::Marker;
-use marker::Marker::*;
 use std::io::{self, Read};
+use crate::{read_u16_from_be, read_u8};
+use crate::error::{Error, Result, UnsupportedFeature};
+use crate::huffman::{HuffmanTable, HuffmanTableClass};
+use crate::marker::Marker;
+use crate::marker::Marker::*;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Dimensions {

--- a/src/upsampler.rs
+++ b/src/upsampler.rs
@@ -1,8 +1,8 @@
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
-use error::{Error, Result, UnsupportedFeature};
-use parser::Component;
+use crate::error::{Error, Result, UnsupportedFeature};
+use crate::parser::Component;
 
 pub struct Upsampler {
     components: Vec<UpsamplerComponent>,

--- a/src/worker/immediate.rs
+++ b/src/worker/immediate.rs
@@ -2,11 +2,11 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::mem;
 use core::convert::TryInto;
-use decoder::MAX_COMPONENTS;
-use error::Result;
-use idct::dequantize_and_idct_block;
-use alloc::sync::Arc;
-use parser::Component;
+use crate::decoder::MAX_COMPONENTS;
+use crate::error::Result;
+use crate::idct::dequantize_and_idct_block;
+use crate::alloc::sync::Arc;
+use crate::parser::Component;
 use super::{RowData, Worker};
 
 pub struct ImmediateWorker {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -8,8 +8,8 @@ pub use self::immediate::ImmediateWorker as PlatformWorker;
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use error::Result;
-use parser::Component;
+use crate::error::Result;
+use crate::parser::Component;
 
 pub struct RowData {
     pub index: usize,

--- a/src/worker/multithreaded.rs
+++ b/src/worker/multithreaded.rs
@@ -4,9 +4,9 @@
 //! and allow scaling to more cores.
 //! However, that would be more complex, so we use this as a starting point.
 
-use decoder::MAX_COMPONENTS;
-use error::Result;
 use std::{mem, io, sync::mpsc::{self, Sender}};
+use crate::decoder::MAX_COMPONENTS;
+use crate::error::Result;
 use super::{RowData, Worker};
 use super::immediate::ImmediateWorker;
 


### PR DESCRIPTION
While looking into `no std` support i ran into some module related problems (mostly handling of `core`) that are easier to solve with edition 2018.
Because MSVR is 1.48 and edition 2018 has been stabilized with 1.31, upgrading shouldn't cause any problems for users of this crate.

