### PR TITLE
Restructure multithreading

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - name: Installing emulator and linker
         run: |
+          sudo apt-get update
           sudo apt-get install qemu binfmt-support qemu-user-static gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
 
       - name: Installing Rust toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,13 @@ png = "0.16"
 walkdir = "2.0"
 criterion = "0.3"
 
+[features]
+default = ["rayon"]
+platform_independent = []
+nightly_aarch64_neon = []
+
+## Internal development configuration: testing and benchmarking
+
 [[bench]]
 name = "decoding_benchmark"
 harness = false
@@ -31,8 +38,10 @@ harness = false
 name = "rayon"
 required-features = ["rayon"]
 
-[features]
-default = ["rayon"]
-platform_independent = []
-nightly_aarch64_neon = []
+[[test]]
+name = "rayon-0"
+required-features = ["rayon"]
 
+[[test]]
+name = "rayon-1"
+required-features = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ harness = false
 name = "large_image"
 harness = false
 
+[[test]]
+name = "rayon"
+required-features = ["rayon"]
+
 [features]
 default = ["rayon"]
 platform_independent = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ required-features = ["rayon"]
 [[test]]
 name = "rayon-1"
 required-features = ["rayon"]
+
+[[test]]
+name = "rayon-2"
+required-features = ["rayon"]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -17,7 +17,7 @@ use crate::parser::{
     IccChunk, ScanInfo,
 };
 use crate::upsampler::Upsampler;
-use crate::worker::{PlatformWorker, RowData, Worker};
+use crate::worker::{PreferWorkerKind, RowData, Worker, with_worker};
 
 pub const MAX_COMPONENTS: usize = 4;
 
@@ -191,7 +191,9 @@ impl<R: Read> Decoder<R> {
     ///
     /// If successful, the metadata can be obtained using the `info` method.
     pub fn read_info(&mut self) -> Result<()> {
-        self.decode_internal(true).map(|_| ())
+        with_worker(PreferWorkerKind::Multithreaded, |worker| {
+            self.decode_internal(true, worker)
+        }).map(|_| ())
     }
 
     /// Configure the decoder to scale the image during decoding.
@@ -219,10 +221,16 @@ impl<R: Read> Decoder<R> {
 
     /// Decodes the image and returns the decoded pixels if successful.
     pub fn decode(&mut self) -> Result<Vec<u8>> {
-        self.decode_internal(false)
+        with_worker(PreferWorkerKind::Multithreaded, |worker| {
+            self.decode_internal(false, worker)
+        })
     }
 
-    fn decode_internal(&mut self, stop_after_metadata: bool) -> Result<Vec<u8>> {
+    fn decode_internal(
+        &mut self,
+        stop_after_metadata: bool,
+        worker: &mut dyn Worker,
+    ) -> Result<Vec<u8>> {
         if stop_after_metadata && self.frame.is_some() {
             // The metadata has already been read.
             return Ok(Vec::new());
@@ -237,7 +245,6 @@ impl<R: Read> Decoder<R> {
 
         let mut previous_marker = Marker::SOI;
         let mut pending_marker = None;
-        let mut worker = None;
         let mut scans_processed = 0;
         let mut planes = vec![
             Vec::<u8>::new();
@@ -318,9 +325,6 @@ impl<R: Read> Decoder<R> {
                     if self.frame.is_none() {
                         return Err(Error::Format("scan encountered before frame".to_owned()));
                     }
-                    if worker.is_none() {
-                        worker = Some(PlatformWorker::new()?);
-                    }
 
                     let frame = self.frame.clone().unwrap();
                     let scan = parse_sos(&mut self.reader, &frame)?;
@@ -383,7 +387,7 @@ impl<R: Read> Decoder<R> {
                         }
 
                         let (marker, data) =
-                            self.decode_scan(&frame, &scan, worker.as_mut().unwrap(), &finished)?;
+                            self.decode_scan(&frame, &scan, worker, &finished)?;
 
                         if let Some(data) = data {
                             for (i, plane) in data
@@ -545,10 +549,6 @@ impl<R: Read> Decoder<R> {
                     };
 
                 // Get the worker prepared
-                if worker.is_none() {
-                    worker = Some(PlatformWorker::new()?);
-                }
-                let worker = worker.as_mut().unwrap();
                 let row_data = RowData {
                     index: i,
                     component: component.clone(),
@@ -616,7 +616,7 @@ impl<R: Read> Decoder<R> {
         &mut self,
         frame: &FrameInfo,
         scan: &ScanInfo,
-        worker: &mut PlatformWorker,
+        worker: &mut dyn Worker,
         finished: &[bool; MAX_COMPONENTS],
     ) -> Result<(Option<Marker>, Option<Vec<Vec<u8>>>)> {
         assert!(scan.component_indices.len() <= MAX_COMPONENTS);

--- a/src/worker/immediate.rs
+++ b/src/worker/immediate.rs
@@ -10,10 +10,10 @@ use crate::parser::Component;
 use super::{RowData, Worker};
 
 pub struct ImmediateWorker {
-    pub(crate) offsets: [usize; MAX_COMPONENTS],
-    pub(crate) results: Vec<Vec<u8>>,
-    pub(crate) components: Vec<Option<Component>>,
-    pub(crate) quantization_tables: Vec<Option<Arc<[u16; 64]>>>,
+    offsets: [usize; MAX_COMPONENTS],
+    results: Vec<Vec<u8>>,
+    components: Vec<Option<Component>>,
+    quantization_tables: Vec<Option<Arc<[u16; 64]>>>,
 }
 
 pub fn with_immediate<T>(f: impl FnOnce(&mut dyn Worker) -> T) -> T {

--- a/src/worker/immediate.rs
+++ b/src/worker/immediate.rs
@@ -10,10 +10,10 @@ use crate::parser::Component;
 use super::{RowData, Worker};
 
 pub struct ImmediateWorker {
-    offsets: [usize; MAX_COMPONENTS],
-    results: Vec<Vec<u8>>,
-    components: Vec<Option<Component>>,
-    quantization_tables: Vec<Option<Arc<[u16; 64]>>>,
+    pub(crate) offsets: [usize; MAX_COMPONENTS],
+    pub(crate) results: Vec<Vec<u8>>,
+    pub(crate) components: Vec<Option<Component>>,
+    pub(crate) quantization_tables: Vec<Option<Arc<[u16; 64]>>>,
 }
 
 pub fn with_immediate<T>(f: impl FnOnce(&mut dyn Worker) -> T) -> T {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1,11 +1,6 @@
 mod immediate;
 mod multithreaded;
 
-#[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))]
-pub use self::multithreaded::MultiThreadedWorker as PlatformWorker;
-#[cfg(any(target_arch = "asmjs", target_arch = "wasm32"))]
-pub use self::immediate::ImmediateWorker as PlatformWorker;
-
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use crate::error::Result;
@@ -17,9 +12,22 @@ pub struct RowData {
     pub quantization_table: Arc<[u16; 64]>,
 }
 
-pub trait Worker: Sized {
-    fn new() -> Result<Self>;
+pub trait Worker {
     fn start(&mut self, row_data: RowData) -> Result<()>;
     fn append_row(&mut self, row: (usize, Vec<i16>)) -> Result<()>;
     fn get_result(&mut self, index: usize) -> Result<Vec<u8>>;
+}
+
+pub enum PreferWorkerKind {
+    Immediate,
+    Multithreaded,
+}
+
+/// Execute something with a worker system.
+pub fn with_worker<T>(prefer: PreferWorkerKind, f: impl FnOnce(&mut dyn Worker) -> T) -> T {
+    match prefer {
+        #[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))]
+        PreferWorkerKind::Multithreaded => self::multithreaded::with_multithreading(f),
+        _ => self::immediate::with_immediate(f),
+    }
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1,5 +1,7 @@
 mod immediate;
 mod multithreaded;
+#[cfg(feature = "rayon")]
+mod rayon;
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -16,6 +18,15 @@ pub trait Worker {
     fn start(&mut self, row_data: RowData) -> Result<()>;
     fn append_row(&mut self, row: (usize, Vec<i16>)) -> Result<()>;
     fn get_result(&mut self, index: usize) -> Result<Vec<u8>>;
+    /// Default implementation for spawning multiple tasks.
+    fn append_rows(&mut self, row: &mut dyn Iterator<Item=(usize, Vec<i16>)>)
+        -> Result<()>
+    {
+        for item in row {
+            self.append_row(item)?;
+        }
+        Ok(())
+    }
 }
 
 pub enum PreferWorkerKind {
@@ -26,6 +37,9 @@ pub enum PreferWorkerKind {
 /// Execute something with a worker system.
 pub fn with_worker<T>(prefer: PreferWorkerKind, f: impl FnOnce(&mut dyn Worker) -> T) -> T {
     match prefer {
+        #[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))]
+        #[cfg(feature = "rayon")]
+        PreferWorkerKind::Multithreaded => self::rayon::with_rayon(f),
         #[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))]
         PreferWorkerKind::Multithreaded => self::multithreaded::with_multithreading(f),
         _ => self::immediate::with_immediate(f),

--- a/src/worker/multithreaded.rs
+++ b/src/worker/multithreaded.rs
@@ -4,34 +4,48 @@
 //! and allow scaling to more cores.
 //! However, that would be more complex, so we use this as a starting point.
 
-use std::{mem, io, sync::mpsc::{self, Sender}};
+use std::{mem, sync::mpsc::{self, Receiver, Sender}};
 use crate::decoder::MAX_COMPONENTS;
 use crate::error::Result;
 use super::{RowData, Worker};
 use super::immediate::ImmediateWorker;
+
+pub fn with_multithreading<T>(f: impl FnOnce(&mut dyn Worker) -> T) -> T {
+    #[cfg(not(feature = "rayon"))]
+    return self::enter_threads(f);
+
+    #[cfg(feature = "rayon")]
+    return jpeg_rayon::enter(|mut worker| {
+        f(&mut worker)
+    });
+}
 
 enum WorkerMsg {
     Start(RowData),
     AppendRow(Vec<i16>),
     GetResult(Sender<Vec<u8>>),
 }
-pub struct MultiThreadedWorker {
+
+#[derive(Default)]
+pub struct MpscWorker {
     senders: [Option<Sender<WorkerMsg>>; MAX_COMPONENTS]
 }
 
-impl Worker for MultiThreadedWorker {
-    fn new() -> Result<Self> {
-        Ok(MultiThreadedWorker {
-            senders: [None, None, None, None]
-        })
-    }
-    fn start(&mut self, row_data: RowData) -> Result<()> {
+pub struct StdThreadWorker(MpscWorker);
+
+impl MpscWorker {
+    fn start_with(
+        &mut self,
+        row_data: RowData,
+        spawn_worker: impl FnOnce(usize) -> Result<Sender<WorkerMsg>>,
+    ) -> Result<()> {
         // if there is no worker thread for this component yet, start one
         let component = row_data.index;
         if let None = self.senders[component] {
-            let sender = spawn_worker_thread(component)?;
+            let sender = spawn_worker(component)?;
             self.senders[component] = Some(sender);
         }
+
         // we do the "take out value and put it back in once we're done" dance here
         // and in all other message-passing methods because there's not that many rows
         // and this should be cheaper than spawning MAX_COMPONENTS many threads up front
@@ -40,6 +54,7 @@ impl Worker for MultiThreadedWorker {
         self.senders[component] = Some(sender);
         Ok(())
     }
+
     fn append_row(&mut self, row: (usize, Vec<i16>)) -> Result<()> {
         let component = row.0;
         let sender = mem::replace(&mut self.senders[component], None).unwrap();
@@ -47,18 +62,34 @@ impl Worker for MultiThreadedWorker {
         self.senders[component] = Some(sender);
         Ok(())
     }
-    fn get_result(&mut self, index: usize) -> Result<Vec<u8>> {
+
+    fn get_result_with(
+        &mut self,
+        index: usize,
+        collect: impl FnOnce(Receiver<Vec<u8>>) -> Vec<u8>,
+    ) -> Result<Vec<u8>> {
         let (tx, rx) = mpsc::channel();
         let sender = mem::replace(&mut self.senders[index], None).unwrap();
         sender.send(WorkerMsg::GetResult(tx)).expect("jpeg-decoder worker thread error");
-        Ok(rx.recv().expect("jpeg-decoder worker thread error"))
+        Ok(collect(rx))
     }
 }
 
-fn spawn_worker_thread(component: usize) -> Result<Sender<WorkerMsg>> {
-    let (tx, rx) = mpsc::channel();
+impl Worker for StdThreadWorker {
+    fn start(&mut self, row_data: RowData) -> Result<()> {
+        self.0.start_with(row_data, spawn_worker_thread)
+    }
+    fn append_row(&mut self, row: (usize, Vec<i16>)) -> Result<()> {
+        self.0.append_row(row)
+    }
+    fn get_result(&mut self, index: usize) -> Result<Vec<u8>> {
+        self.0.get_result_with(index, collect_worker_thread)
+    }
+}
 
-    spawn(component, move || {
+fn create_worker() -> (Sender<WorkerMsg>, impl FnOnce() + 'static) {
+    let (tx, rx) = mpsc::channel();
+    let closure = move || {
         let mut worker = ImmediateWorker::new_immediate();
 
         while let Ok(message) = rx.recv() {
@@ -79,27 +110,93 @@ fn spawn_worker_thread(component: usize) -> Result<Sender<WorkerMsg>> {
                 },
             }
         }
-    })?;
+    };
 
+    (tx, closure)
+}
+
+fn spawn_worker_thread(component: usize) -> Result<Sender<WorkerMsg>> {
+    let (tx, worker) = create_worker();
+    let thread_builder =
+        std::thread::Builder::new().name(format!("worker thread for component {}", component));
+    thread_builder.spawn(worker)?;
     Ok(tx)
 }
 
-#[cfg(feature = "rayon")]
-fn spawn<F>(_component: usize, func: F) -> io::Result<()>
-where
-    F: FnOnce() + Send + 'static,
-{
-    rayon::spawn(func);
-    Ok(())
+
+fn collect_worker_thread(rx: Receiver<Vec<u8>>) -> Vec<u8> {
+    rx.recv().expect("jpeg-decoder worker thread error")
 }
 
-#[cfg(not(feature = "rayon"))]
-fn spawn<F>(component: usize, func: F) -> io::Result<()>
-where
-    F: FnOnce() + Send + 'static,
-{
-    let thread_builder =
-        std::thread::Builder::new().name(format!("worker thread for component {}", component));
-    thread_builder.spawn(func)?;
-    Ok(())
+#[allow(dead_code)]
+fn enter_threads<T>(f: impl FnOnce(&mut dyn Worker) -> T) -> T {
+    let mut worker = StdThreadWorker(MpscWorker::default());
+    f(&mut worker)
 }
+
+
+#[cfg(feature = "rayon")]
+mod jpeg_rayon {
+    use crate::error::Result;
+    use super::{MpscWorker, RowData};
+
+    pub struct Scoped<'r, 'scope> {
+        fifo: &'r rayon::ScopeFifo<'scope>,
+        inner: MpscWorker,
+    }
+
+    pub fn enter<T>(f: impl FnOnce(Scoped) -> T) -> T {
+        // Note: Must be at least two threads. Otherwise, we may deadlock, due to ordering
+        // constraints that we can not impose properly. Note that `append_row` creates a new task
+        // while in `get_result` we wait for all tasks of a component. The only way for rayon to
+        // impose this wait __and get a result__ is by ending an in_place_scope.
+        //
+        // However, the ordering of tasks is not as FIFO as the name would suggest. Indeed, even
+        // though tasks are spawned in `start` _before_ the task spawned in `get_result`, the
+        // `in_place_scope_fifo` will wait for ITS OWN results in fifo order. This implies, unless
+        // there is some other thread capable of stealing the worker the work task will in fact not
+        // get executed and the result will wait forever. It is impossible to otherwise schedule
+        // the worker tasks specifically (e.g. join handle would be cool *cough* if you read this
+        // and work on rayon) before while yielding from the current thread.
+        //
+        // So: we need at least one more worker thread that is _not_ occupied.
+        let threads = rayon::ThreadPoolBuilder::new().num_threads(4).build().unwrap();
+
+        threads.in_place_scope_fifo(|fifo| {
+            f(Scoped { fifo, inner: MpscWorker::default() })
+        })
+    }
+
+    impl super::Worker for Scoped<'_, '_> {
+        fn start(&mut self, row_data: RowData) -> Result<()> {
+            let fifo = &mut self.fifo;
+            self.inner.start_with(row_data, |_| {
+                let (tx, worker) = super::create_worker();
+                fifo.spawn_fifo(move |_| {
+                    worker()
+                });
+                Ok(tx)
+            })
+        }
+
+        fn append_row(&mut self, row: (usize, Vec<i16>)) -> Result<()> {
+            self.inner.append_row(row)
+        }
+
+        fn get_result(&mut self, index: usize) -> Result<Vec<u8>> {
+            self.inner.get_result_with(index, |rx| {
+                let mut result = vec![];
+                let deliver_result = &mut result;
+
+                rayon::in_place_scope_fifo(|scope| {
+                    scope.spawn_fifo(move |_| {
+                        *deliver_result = rx.recv().expect("jpeg-decoder worker thread error");
+                    });
+                });
+
+                result
+            })
+        }
+    }
+}
+

--- a/src/worker/rayon.rs
+++ b/src/worker/rayon.rs
@@ -1,0 +1,117 @@
+use core::convert::TryInto;
+use crate::error::Result;
+use crate::idct::dequantize_and_idct_block;
+
+use std::sync::Mutex;
+
+use super::{RowData, Worker};
+use crate::worker::immediate::ImmediateWorker;
+
+pub struct Scoped {
+    inner: Mutex<ImmediateWorker>,
+}
+
+pub fn with_rayon<T>(f: impl FnOnce(&mut dyn Worker) -> T) -> T {
+    rayon::in_place_scope(|_| {
+        let inner = ImmediateWorker::new_immediate();
+        f(&mut Scoped { inner: Mutex::new(inner) })
+    })
+}
+
+impl Scoped {
+    pub fn append_row_locked(
+        mutex: &Mutex<ImmediateWorker>,
+        (index, data): (usize, Vec<i16>),
+        result_offset: usize,
+    ) {
+        // Convert coefficients from a MCU row to samples.
+        let quantization_table;
+        let block_count;
+        let line_stride;
+        let block_size;
+        let dct_scale;
+
+        {
+            let inner = mutex.lock().unwrap();
+            let component = inner.components[index].as_ref().unwrap();
+            quantization_table = inner.quantization_tables[index].as_ref().unwrap().clone();
+
+            block_size = component.block_size;
+            block_count = block_size.width as usize * component.vertical_sampling_factor as usize;
+            line_stride = block_size.width as usize * component.dct_scale;
+            dct_scale = component.dct_scale;
+        }
+
+        assert_eq!(data.len(), block_count * 64);
+
+        let mut output_buffer = [0; 64];
+        for i in 0..block_count {
+            let x = (i % block_size.width as usize) * dct_scale;
+            let y = (i / block_size.width as usize) * dct_scale;
+
+            let coefficients: &[i16; 64] = &data[i * 64..(i + 1) * 64].try_into().unwrap();
+
+            // Write to a temporary intermediate buffer, a 8x8 'image'.
+            dequantize_and_idct_block(dct_scale, coefficients, &*quantization_table, 8, &mut output_buffer);
+
+            // Lock the mutex only for this write back, not the main computation.
+            // FIXME: we are only copying image data. Can we use some atomic backing buffer and a
+            // `Relaxed` write instead?
+            let mut write_back = mutex.lock().unwrap();
+            let write_back = &mut write_back.results[index][result_offset + y * line_stride + x..];
+
+            let buffered_lines = output_buffer.chunks_mut(8);
+            let back_lines = write_back.chunks_mut(line_stride);
+
+            for (buf, back) in buffered_lines.zip(back_lines).take(dct_scale) {
+                back[..dct_scale].copy_from_slice(&buf[..dct_scale]);
+            }
+        }
+    }
+}
+
+impl super::Worker for Scoped {
+    fn start(&mut self, row_data: RowData) -> Result<()> {
+        self.inner.get_mut().unwrap().start_immediate(row_data);
+        Ok(())
+    }
+
+    fn append_row(&mut self, row: (usize, Vec<i16>)) -> Result<()> {
+        self.inner.get_mut().unwrap().append_row_immediate(row);
+        Ok(())
+    }
+
+    fn get_result(&mut self, index: usize) -> Result<Vec<u8>> {
+        let result = self.inner.get_mut().unwrap().get_result_immediate(index);
+        Ok(result)
+    }
+
+    // Magic sauce, these _may_ run in parallel.
+    fn append_rows(&mut self, iter: &mut dyn Iterator<Item=(usize, Vec<i16>)>)
+        -> Result<()>
+    {
+        rayon::in_place_scope(|scope| {
+            let mut inner = self.inner.lock().unwrap();
+            // First we schedule everything, making sure their index is right etc.
+            for (index, data) in iter {
+                let component = inner.components[index].as_ref().unwrap();
+
+                let block_size = component.block_size;
+                let block_count = block_size.width as usize * component.vertical_sampling_factor as usize;
+                let dct_scale = component.dct_scale;
+
+                let result_offset = inner.offsets[index];
+                inner.offsets[index] += block_count * dct_scale * dct_scale;
+
+                let mutex = &self.inner;
+                scope.spawn(move |_| {
+                    Scoped::append_row_locked(mutex, (index, data), result_offset)
+                });
+            }
+
+            // Then the mutex is released, allowing all tasks to run.
+        });
+
+        Ok(())
+    }
+}

--- a/src/worker/rayon.rs
+++ b/src/worker/rayon.rs
@@ -31,11 +31,9 @@ pub struct Scoped {
 }
 
 pub fn with_rayon<T>(f: impl FnOnce(&mut dyn Worker) -> T) -> T {
-    rayon::in_place_scope(|_| {
-        let inner = ImmediateWorker::default();
-        f(&mut Scoped {
-            inner: Mutex::new(inner),
-        })
+    let inner = ImmediateWorker::default();
+    f(&mut Scoped {
+        inner: Mutex::new(inner),
     })
 }
 

--- a/tests/rayon-0.rs
+++ b/tests/rayon-0.rs
@@ -1,0 +1,16 @@
+//! Must be a separate test because it modifies the _global_ rayon pool.
+use std::{fs::File, path::Path};
+use jpeg_decoder::Decoder;
+
+#[test]
+fn decoding_in_global_pool() {
+    let path = Path::new("tests").join("reftest").join("images").join("mozilla").join("jpg-progressive.jpg");
+
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build_global()
+        .unwrap();
+
+    let mut decoder = Decoder::new(File::open(&path).unwrap());
+    let _ = decoder.decode().unwrap();
+}

--- a/tests/rayon-1.rs
+++ b/tests/rayon-1.rs
@@ -1,0 +1,18 @@
+//! Must be a separate test because it modifies the _global_ rayon pool.
+use std::{fs::File, path::Path};
+use jpeg_decoder::Decoder;
+
+#[test]
+fn decoding_in_fetched_global_pool() {
+    let path = Path::new("tests").join("reftest").join("images").join("mozilla").join("jpg-progressive.jpg");
+
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build_global()
+        .unwrap();
+
+    rayon::scope(|_| {
+        let mut decoder = Decoder::new(File::open(&path).unwrap());
+        let _ = decoder.decode().unwrap();
+    })
+}

--- a/tests/rayon-2.rs
+++ b/tests/rayon-2.rs
@@ -1,0 +1,23 @@
+//! Must be a separate test because it modifies the _global_ rayon pool.
+use std::{fs::File, path::Path};
+use jpeg_decoder::Decoder;
+
+#[test]
+fn decoding_in_global_pool() {
+    let path = Path::new("tests/reftest/images/progressive3.jpg");
+
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(2)
+        .build_global()
+        .unwrap();
+
+    let _: Vec<_> = (0..1024)
+        .map(|_| {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                let mut decoder = Decoder::new(File::open(&path).unwrap());
+                let _ = decoder.decode().unwrap();
+            });
+        }).collect();
+}
+

--- a/tests/rayon.rs
+++ b/tests/rayon.rs
@@ -1,0 +1,16 @@
+use std::{fs::File, path::Path};
+use jpeg_decoder::Decoder;
+
+#[test]
+fn decoding_in_limited_threadpool_does_not_deadlock() {
+    let path = Path::new("tests").join("reftest").join("images").join("mozilla").join("jpg-progressive.jpg");
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .unwrap();
+    pool.install(|| {
+        let mut decoder = Decoder::new(File::open(&path).unwrap());
+        let _ = decoder.decode().unwrap();
+    });
+}


### PR DESCRIPTION
Redefine the Worker trait, which allows the chosen worker to create a
new scope. This is relevant for a newly created (and installed) rayon
worker.

The rayon thread pool is now local to the decoding step. This fixes an
issue where improper task scheduling would deadlock decoding. It's not
clear how the intended task scheduling can be reliably achieved without
the guarantee of having at least a second, free, worker thread.

Closes: #227 