### PR TITLE
Bump rayon: 1.0 -> 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["tests/*"]
 edition = "2018"
 
 [dependencies]
-rayon = { version = "1.0", optional = true }
+rayon = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 png = "0.16"


### PR DESCRIPTION
Fixes a compile error when building with minimal dependency versions:

```sh
  cargo hack --remove-dev-deps --workspace
  cargo +nightly update -Z minimal-versions
  cargo +1.48.0 check
```

`rayon v1.1.0` is the first (minimal) version that builds with Rust 1.48.0. `rayon v1.0.0` (which satisfies `version = "1.0"`) fails like this:

```
error: expected identifier, found `"std"`
  --> /home/inty/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.1.1/rust/src/liblibc/lib.rs:79:46
   |
79 | #[cfg(feature = "cargo-build")] extern crate "std" as core;
   |                                              ^^^^^ expected identifier

error: aborting due to previous error

error: could not compile `libc`
```

This should also make `image` buildable with `-Z minimal-versions`.

Context: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277 (opinionated, but contains useful workflows)