### PR TITLE
Release 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.2.5 (2022-05-02)
+
+- Fix single threaded usage in WASM target.
+
 ## v0.2.4 (2022-04-01)
 
 - Corrects minimal version requirements of dependency `rayon`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpeg-decoder"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["The image-rs Developers"]
 description = "JPEG decoder"
 documentation = "https://docs.rs/jpeg-decoder"


### PR DESCRIPTION
Replaces #237 

Since we do releases based on the feature branch itself (not the automatic merge, as it's unnnamed and potentially different) rebased this on master and pushed. Originally, I wanted to push this to the fork but accidentally pushed `master`, which auto-closed the through github. And without an active PR I'm no longer allowed to update the branch / undo that mistake :smile:  