### PR TITLE
Enable cloning of `UnsupportedFeature` to allow use in image-tiff crate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// An enumeration over JPEG features (currently) unsupported by this library.
 ///
 /// Support for features listed here may be included in future versions of this library.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum UnsupportedFeature {
     /// Hierarchical JPEG.
     Hierarchical,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
-use alloc::string::String;
 use alloc::fmt;
+use alloc::string::String;
 use core::result;
 use std::error::Error as StdError;
 use std::io::Error as IoError;
@@ -10,7 +10,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// An enumeration over JPEG features (currently) unsupported by this library.
 ///
 /// Support for features listed here may be included in future versions of this library.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum UnsupportedFeature {
     /// Hierarchical JPEG.
     Hierarchical,
@@ -46,10 +46,10 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Format(ref desc)      => write!(f, "invalid JPEG format: {}", desc),
+            Error::Format(ref desc) => write!(f, "invalid JPEG format: {}", desc),
             Error::Unsupported(ref feat) => write!(f, "unsupported JPEG feature: {:?}", feat),
-            Error::Io(ref err)           => err.fmt(f),
-            Error::Internal(ref err)     => err.fmt(f),
+            Error::Io(ref err) => err.fmt(f),
+            Error::Internal(ref err) => err.fmt(f),
         }
     }
 }


### PR DESCRIPTION
To solve https://github.com/image-rs/image-tiff/issues/168 I would like to clone the `UnsupportedFeature` error and add this to a `TiffError` to pass back to the caller.