### PR TITLE
Override colour transform

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1333,6 +1333,9 @@ pub(crate) fn choose_color_convert_func(
     match component_count {
         3 => match color_transform {
             ColorTransform::None => Ok(color_no_convert),
+            ColorTransform::Grayscale => Err(Error::Format(
+                "Invalid number of channels (3) for Grayscale data".to_string(),
+            )),
             ColorTransform::RGB => Ok(color_convert_line_rgb),
             ColorTransform::YCbCr => Ok(color_convert_line_ycbcr),
             ColorTransform::CMYK => Err(Error::Format(
@@ -1348,12 +1351,12 @@ pub(crate) fn choose_color_convert_func(
                 UnsupportedFeature::ColorTransform(ColorTransform::JcsBgRgb),
             )),
             ColorTransform::Unknown => Err(Error::Format("Unknown colour transform".to_string())),
-            ColorTransform::Grayscale => Err(Error::Unsupported(
-                UnsupportedFeature::ColorTransform(ColorTransform::Grayscale),
-            )),
         },
         4 => match color_transform {
             ColorTransform::None => Ok(color_no_convert),
+            ColorTransform::Grayscale => Err(Error::Format(
+                "Invalid number of channels (4) for Grayscale data".to_string(),
+            )),
             ColorTransform::RGB => Err(Error::Format(
                 "Invalid number of channels (4) for RGB data".to_string(),
             )),
@@ -1370,9 +1373,6 @@ pub(crate) fn choose_color_convert_func(
                 UnsupportedFeature::ColorTransform(ColorTransform::JcsBgRgb),
             )),
             ColorTransform::Unknown => Err(Error::Format("Unknown colour transform".to_string())),
-            ColorTransform::Grayscale => Err(Error::Unsupported(
-                UnsupportedFeature::ColorTransform(ColorTransform::Grayscale),
-            )),
         },
         _ => panic!(),
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -752,6 +752,8 @@ impl<R: Read> Decoder<R> {
 
         if frame.components.len() == 4 {
             ColorTransform::YCCK
+        } else if frame.components.len() == 3 {
+            ColorTransform::YCbCr
         } else {
             ColorTransform::Unknown
         }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -675,12 +675,6 @@ impl<R: Read> Decoder<R> {
         if frame.coding_process == CodingProcess::Lossless {
             compute_image_lossless(frame, planes_u16)
         } else {
-            // Check whether a colour transform has been set - if not use the fallback
-            // let color_transform = match self.color_transform {
-            //     Some(color_transform) => color_transform,
-            //     None => self.fallback_color_transform,
-            // };
-
             compute_image(
                 &frame.components,
                 planes,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -685,7 +685,6 @@ impl<R: Read> Decoder<R> {
                 &frame.components,
                 planes,
                 frame.output_size,
-                self.is_jfif,
                 self.determine_color_transform(),
             )
         }
@@ -1294,7 +1293,6 @@ fn compute_image(
     components: &[Component],
     mut data: Vec<Vec<u8>>,
     output_size: Dimensions,
-    is_jfif: bool,
     color_transform: ColorTransform,
 ) -> Result<Vec<u8>> {
     if data.is_empty() || data.iter().any(Vec::is_empty) {
@@ -1325,13 +1323,12 @@ fn compute_image(
         decoded.resize(size, 0);
         Ok(decoded)
     } else {
-        compute_image_parallel(components, data, output_size, is_jfif, color_transform)
+        compute_image_parallel(components, data, output_size, color_transform)
     }
 }
 
 pub(crate) fn choose_color_convert_func(
     component_count: usize,
-    _is_jfif: bool,
     color_transform: ColorTransform,
 ) -> Result<fn(&[Vec<u8>], &mut [u8])> {
     match component_count {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -746,6 +746,8 @@ impl<R: Read> Decoder<R> {
                     return ColorTransform::YCCK;
                 }
             }
+        } else if frame.components.len() == 4 {
+            return ColorTransform::CMYK;
         }
 
         if frame.components.len() == 4 {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -76,6 +76,7 @@ pub struct ImageInfo {
 
 /// Describes the colour transform to apply before binary data is returned
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum ColorTransform {
     /// No transform should be applied and the data is returned as-is.
     None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,8 @@ pub enum UnsupportedFeature {
     SubsamplingRatio,
     /// A subsampling ratio not representable as an integer.
     NonIntegerSubsamplingRatio,
+    /// Colour transform
+    ColorTransform(ColorTransform),
 }
 
 /// Errors that can occur while decoding a JPEG image.

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use core::result;
 use std::error::Error as StdError;
 use std::io::Error as IoError;
 
+use crate::ColorTransform;
+
 pub type Result<T> = result::Result<T, Error>;
 
 /// An enumeration over JPEG features (currently) unsupported by this library.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ extern crate core;
 #[cfg(feature = "rayon")]
 extern crate rayon;
 
-pub use decoder::{Decoder, ImageInfo, PixelFormat};
+pub use decoder::{ColorTransform, Decoder, ImageInfo, PixelFormat};
 pub use error::{Error, UnsupportedFeature};
 pub use parser::CodingProcess;
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -98,19 +98,17 @@ pub fn compute_image_parallel(
     components: &[Component],
     data: Vec<Vec<u8>>,
     output_size: Dimensions,
-    is_jfif: bool,
     color_transform: ColorTransform,
 ) -> Result<Vec<u8>> {
     #[cfg(all(
         not(any(target_arch = "asmjs", target_arch = "wasm32")),
         feature = "rayon"
     ))]
-    return rayon::compute_image_parallel(components, data, output_size, is_jfif, color_transform);
+    return rayon::compute_image_parallel(components, data, output_size, color_transform);
 
     #[allow(unreachable_code)]
     {
-        let color_convert_func =
-            choose_color_convert_func(components.len(), is_jfif, color_transform)?;
+        let color_convert_func = choose_color_convert_func(components.len(), color_transform)?;
         let upsampler = Upsampler::new(components, output_size.width, output_size.height)?;
         let line_size = output_size.width as usize * components.len();
         let mut image = vec![0u8; line_size * output_size.height as usize];

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -6,14 +6,14 @@ mod multithreaded;
 ))]
 mod rayon;
 
-use crate::decoder::choose_color_convert_func;
+use crate::decoder::{choose_color_convert_func, ColorTransform};
 use crate::error::Result;
-use crate::parser::{AdobeColorTransform, Component, Dimensions};
+use crate::parser::{Component, Dimensions};
 use crate::upsampler::Upsampler;
 
-use core::cell::RefCell;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::cell::RefCell;
 
 pub struct RowData {
     pub index: usize,
@@ -66,21 +66,19 @@ impl WorkerScope {
     pub fn get_or_init_worker<T>(
         &self,
         prefer: PreferWorkerKind,
-        f: impl FnOnce(&mut dyn Worker) -> T
+        f: impl FnOnce(&mut dyn Worker) -> T,
     ) -> T {
         let mut inner = self.inner.borrow_mut();
-        let inner = inner.get_or_insert_with(move || {
-            match prefer {
-                #[cfg(all(
-                    not(any(target_arch = "asmjs", target_arch = "wasm32")),
-                    feature = "rayon"
-                ))]
-                PreferWorkerKind::Multithreaded => WorkerScopeInner::Rayon(Default::default()),
-                #[allow(unreachable_patterns)]
-                #[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))]
-                PreferWorkerKind::Multithreaded => WorkerScopeInner::Multithreaded(Default::default()),
-                _ => WorkerScopeInner::Immediate(Default::default()),
-            }
+        let inner = inner.get_or_insert_with(move || match prefer {
+            #[cfg(all(
+                not(any(target_arch = "asmjs", target_arch = "wasm32")),
+                feature = "rayon"
+            ))]
+            PreferWorkerKind::Multithreaded => WorkerScopeInner::Rayon(Default::default()),
+            #[allow(unreachable_patterns)]
+            #[cfg(not(any(target_arch = "asmjs", target_arch = "wasm32")))]
+            PreferWorkerKind::Multithreaded => WorkerScopeInner::Multithreaded(Default::default()),
+            _ => WorkerScopeInner::Immediate(Default::default()),
         });
 
         f(match &mut *inner {
@@ -101,7 +99,7 @@ pub fn compute_image_parallel(
     data: Vec<Vec<u8>>,
     output_size: Dimensions,
     is_jfif: bool,
-    color_transform: Option<AdobeColorTransform>,
+    color_transform: ColorTransform,
 ) -> Result<Vec<u8>> {
     #[cfg(all(
         not(any(target_arch = "asmjs", target_arch = "wasm32")),

--- a/src/worker/rayon.rs
+++ b/src/worker/rayon.rs
@@ -3,7 +3,7 @@ use core::convert::TryInto;
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use rayon::slice::ParallelSliceMut;
 
-use crate::decoder::choose_color_convert_func;
+use crate::decoder::{choose_color_convert_func, ColorTransform};
 use crate::error::Result;
 use crate::idct::dequantize_and_idct_block;
 use crate::parser::{AdobeColorTransform, Component};
@@ -197,7 +197,7 @@ pub fn compute_image_parallel(
     data: Vec<Vec<u8>>,
     output_size: Dimensions,
     is_jfif: bool,
-    color_transform: Option<AdobeColorTransform>,
+    color_transform: ColorTransform,
 ) -> Result<Vec<u8>> {
     let color_convert_func = choose_color_convert_func(components.len(), is_jfif, color_transform)?;
     let upsampler = Upsampler::new(components, output_size.width, output_size.height)?;

--- a/src/worker/rayon.rs
+++ b/src/worker/rayon.rs
@@ -6,7 +6,7 @@ use rayon::slice::ParallelSliceMut;
 use crate::decoder::{choose_color_convert_func, ColorTransform};
 use crate::error::Result;
 use crate::idct::dequantize_and_idct_block;
-use crate::parser::{AdobeColorTransform, Component};
+use crate::parser::Component;
 use crate::upsampler::Upsampler;
 use crate::{decoder::MAX_COMPONENTS, parser::Dimensions};
 
@@ -196,10 +196,9 @@ pub fn compute_image_parallel(
     components: &[Component],
     data: Vec<Vec<u8>>,
     output_size: Dimensions,
-    is_jfif: bool,
     color_transform: ColorTransform,
 ) -> Result<Vec<u8>> {
-    let color_convert_func = choose_color_convert_func(components.len(), is_jfif, color_transform)?;
+    let color_convert_func = choose_color_convert_func(components.len(), color_transform)?;
     let upsampler = Upsampler::new(components, output_size.width, output_size.height)?;
     let line_size = output_size.width as usize * components.len();
     let mut image = vec![0u8; line_size * output_size.height as usize];


### PR DESCRIPTION
Added the ability to set the colour transform applied (resolves https://github.com/image-rs/jpeg-decoder/issues/238).

To do this, I had added a new `enum` which captures the possible options, including a `Default` option which retains the previous behaviour when the `color_transform == None`. 