### PR TITLE
Read the XMP packet

### DIFF
--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -23,6 +23,7 @@ fn main() {
 
     eprintln!("{:?}", info);
     eprintln!("Exif: {}", decoder.exif_data().is_some());
+    eprintln!("XMP: {}", decoder.xmp_data().is_some());
     eprintln!("ICC: {}", decoder.icc_profile().is_some());
 
     let output_file = File::create(output_path).unwrap();

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -118,6 +118,8 @@ pub struct Decoder<R> {
     icc_markers: Vec<IccChunk>,
 
     exif_data: Option<Vec<u8>>,
+    xmp_data: Option<Vec<u8>>,
+    psir_data: Option<Vec<u8>>,
 
     // Used for progressive JPEGs.
     coefficients: Vec<Vec<i16>>,
@@ -144,6 +146,8 @@ impl<R: Read> Decoder<R> {
             is_mjpeg: false,
             icc_markers: Vec::new(),
             exif_data: None,
+            xmp_data: None,
+            psir_data: None,
             coefficients: Vec::new(),
             coefficients_finished: [0; MAX_COMPONENTS],
             decoding_buffer_size_limit: usize::MAX,
@@ -195,6 +199,13 @@ impl<R: Read> Decoder<R> {
     /// The returned value will be `None` until a call to `decode` has returned `Ok`.    
     pub fn exif_data(&self) -> Option<&[u8]> {
         self.exif_data.as_deref()
+    }
+
+    /// Returns the raw XMP packet if there is any.
+    ///
+    /// The returned value will be `None` until a call to `decode` has returned `Ok`.
+    pub fn xmp_data(&self) -> Option<&[u8]> {
+        self.xmp_data.as_deref()
     }
 
     /// Returns the embeded icc profile if the image contains one.
@@ -542,6 +553,8 @@ impl<R: Read> Decoder<R> {
                             AppData::Avi1 => self.is_mjpeg = true,
                             AppData::Icc(icc) => self.icc_markers.push(icc),
                             AppData::Exif(data) => self.exif_data = Some(data),
+                            AppData::Xmp(data) => self.xmp_data = Some(data),
+                            AppData::Psir(data) => self.psir_data = Some(data),
                         }
                     }
                 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -154,3 +154,17 @@ fn read_exif_data() {
     // exif data start as a TIFF header
     assert_eq!(&exif_data[0..8], b"\x49\x49\x2A\x00\x08\x00\x00\x00");
 }
+
+#[test]
+fn read_xmp_data() {
+    let path = Path::new("tests")
+        .join("reftest")
+        .join("images")
+        .join("ycck.jpg");
+
+    let mut decoder = jpeg::Decoder::new(File::open(&path).unwrap());
+    decoder.decode().unwrap();
+
+    let xmp_data = decoder.xmp_data().unwrap();
+    assert_eq!(&xmp_data[0..9], b"<?xpacket");
+}


### PR DESCRIPTION
- and expose it like exif

This conflict with #267 but not overlap. I can rebase on top of it if it gets merged.

It happen that for the tests, the sample has all what is needed.