### PR TITLE
Use core and alloc a bit more

### DIFF
--- a/src/arch/ssse3.rs
+++ b/src/arch/ssse3.rs
@@ -1,7 +1,8 @@
+use core::ptr;
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "ssse3")]
@@ -139,11 +140,6 @@ pub unsafe fn dequantize_and_idct_block_8x8(
                 .unwrap()
     );
 
-    #[cfg(target_arch = "x86")]
-    use std::arch::x86::*;
-    #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::*;
-
     const SHIFT: i32 = 3;
 
     // Read the DCT coefficients, scale them up and dequantize them.
@@ -183,7 +179,7 @@ pub unsafe fn dequantize_and_idct_block_8x8(
                 _mm_setzero_si128(),
             ),
         );
-        std::ptr::copy_nonoverlapping::<u8>(
+        ptr::copy_nonoverlapping::<u8>(
             buf.as_ptr(),
             output.as_mut_ptr().wrapping_add(output_linestride * i) as *mut _,
             8,
@@ -277,7 +273,7 @@ pub unsafe fn color_convert_line_ycbcr(y: &[u8], cb: &[u8], cr: &[u8], output: &
         let mut data = [0u8; 32];
         _mm_storeu_si128(data.as_mut_ptr() as *mut _, rgb_low);
         _mm_storeu_si128(data.as_mut_ptr().wrapping_add(16) as *mut _, rgb_hi);
-        std::ptr::copy_nonoverlapping::<u8>(
+        ptr::copy_nonoverlapping::<u8>(
             data.as_ptr(),
             output.as_mut_ptr().wrapping_add(24 * i),
             24,

--- a/src/arch/wasm.rs
+++ b/src/arch/wasm.rs
@@ -1,5 +1,5 @@
 #[cfg(target_arch = "wasm32")]
-use std::arch::wasm32::*;
+use core::arch::wasm32::*;
 
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128")]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -16,7 +16,7 @@ use alloc::{format, vec};
 use core::cmp;
 use core::mem;
 use core::ops::Range;
-use std::convert::TryInto;
+use core::convert::TryInto;
 use std::io::Read;
 
 pub const MAX_COMPONENTS: usize = 4;

--- a/src/decoder/lossless.rs
+++ b/src/decoder/lossless.rs
@@ -1,3 +1,5 @@
+use alloc::{format, vec};
+use alloc::vec::Vec;
 use crate::decoder::{Decoder, MAX_COMPONENTS};
 use crate::error::{Error, Result};
 use crate::huffman::HuffmanDecoder;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -11,7 +11,9 @@ use crate::error::Result;
 use crate::parser::{Component, Dimensions};
 use crate::upsampler::Upsampler;
 
+use alloc::boxed::Box;
 use alloc::sync::Arc;
+use alloc::vec;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 

--- a/src/worker/multithreaded.rs
+++ b/src/worker/multithreaded.rs
@@ -4,14 +4,14 @@
 //! and allow scaling to more cores.
 //! However, that would be more complex, so we use this as a starting point.
 
+use alloc::format;
+use alloc::vec::Vec;
+use core::mem;
 use super::immediate::ImmediateWorker;
 use super::{RowData, Worker};
 use crate::decoder::MAX_COMPONENTS;
 use crate::error::Result;
-use std::{
-    mem,
-    sync::mpsc::{self, Receiver, Sender},
-};
+use std::sync::mpsc::{self, Receiver, Sender};
 
 enum WorkerMsg {
     Start(RowData),

--- a/src/worker/rayon.rs
+++ b/src/worker/rayon.rs
@@ -10,7 +10,9 @@ use crate::parser::Component;
 use crate::upsampler::Upsampler;
 use crate::{decoder::MAX_COMPONENTS, parser::Dimensions};
 
-use std::sync::Arc;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use super::{RowData, Worker};
 

--- a/tests/reftest/mod.rs
+++ b/tests/reftest/mod.rs
@@ -1,6 +1,6 @@
 use jpeg;
 use png;
-use std::cmp;
+use core::cmp;
 use std::fs::File;
 use std::path::Path;
 


### PR DESCRIPTION
We still depend mostly on `std::io` and `std::fs`, but the rest can be done without std.