### PR TITLE
Depend on wasm-bindgen 0.2.89 or higher

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,10 +81,10 @@ jobs:
       - name: Install wasm-bindgen
         run: >
           curl -L "$WASMBINDGEN_UPSTREAM"
-          | tar xzf - --strip-components=1 wasm-bindgen-0.2.83-x86_64-unknown-linux-musl/wasm-bindgen-test-runner
+          | tar xzf - --strip-components=1 wasm-bindgen-0.2.89-x86_64-unknown-linux-musl/wasm-bindgen-test-runner
           && sudo mv wasm-bindgen-test-runner /usr/bin/wasm-bindgen-test-runner
         env:
-          WASMBINDGEN_UPSTREAM: https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.83/wasm-bindgen-0.2.83-x86_64-unknown-linux-musl.tar.gz
+          WASMBINDGEN_UPSTREAM: https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.89/wasm-bindgen-0.2.89-x86_64-unknown-linux-musl.tar.gz
       - name: Installing Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -95,7 +95,8 @@ jobs:
       - name: Test
         run: |
           cargo update
-          cargo update -p wasm-bindgen --precise 0.2.83
+          # update wasm-bindgen to the version we want and bring -test along for the ride
+          cargo update -p wasm-bindgen --precise 0.2.89 -p wasm-bindgen-test
           cargo test -vv --target wasm32-unknown-unknown
         env:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ png = "0.16"
 walkdir = "2.0"
 criterion = "0.3"
 wasm-bindgen-test = "0.3"
-wasm-bindgen = "=0.2.83"
+wasm-bindgen = "0.2.89"
 
 [features]
 default = ["rayon"]


### PR DESCRIPTION
wasm-bindgen 0.2.83 is not compatible for a wasm ABI change that rustc wishes to enable by default for wasm, currently gated behind passing the -Zwasm-c-abi flag to rustc.

wasm-bindgen 0.2.89 should exhibit seamless behavior before and after the ABI change matches the C ABI, so depend on that.

For more information, see
- https://github.com/rust-lang/rust/issues/115666
- https://github.com/rust-lang/rust/pull/117918
- https://github.com/rust-lang/rust/issues/122532